### PR TITLE
replacing matlab_SurfStat* with py_SurfStat*: the first interface for…

### DIFF
--- a/surfstat/brainstat_surfstat.py
+++ b/surfstat/brainstat_surfstat.py
@@ -9,226 +9,66 @@ sys.path.append("python")
 
 from SurfStatAvSurf import *
 from SurfStatAvVol import *
-from SurfStatColLim import *
-from SurfStatColormap import *
-from SurfStatCoord2Ind import *
-from SurfStatDataCursor import *
-from SurfStatDataCursorP import *
-from SurfStatDataCursorQ import *
-from SurfStatDelete import *
 from SurfStatEdg import *
 from SurfStatF import *
-from SurfStatInd2Coord import *
-from SurfStatInflate import *
 from SurfStatLinMod import *
-from SurfStatListDir import *
-from SurfStatMaskCut import *
 from SurfStatNorm import *
 from SurfStatP import *
-from SurfStatPCA import *
 from SurfStatPeakClus import *
-from SurfStatPlot import *
 from SurfStatQ import *
-from SurfStatROI import *
-from SurfStatROILabel import *
-from SurfStatReadData import *
-from SurfStatReadData1 import *
-from SurfStatReadSurf import *
-from SurfStatReadSurf1 import *
-from SurfStatReadVol import *
-from SurfStatReadVol1 import *
 from SurfStatResels import *
 from SurfStatSmooth import *
 from SurfStatStand import *
-from SurfStatSurf2Vol import *
 from SurfStatT import *
-from SurfStatView import *
-from SurfStatView1 import *
-from SurfStatViewData import *
-from SurfStatViews import *
-from SurfStatVol2Surf import *
-from SurfStatWriteData import *
-from SurfStatWriteSurf import *
-from SurfStatWriteSurf1 import *
-from SurfStatWriteVol import *
-from SurfStatWriteVol1 import *
 
 
-def BrainStatAvSurf(filenames, fun):
-    return matlab_SurfStatAvSurf(filenames, fun)
+def BrainStatAvSurf(filenames, fun=np.add, output_surfstat=False):
+    return py_SurfStatAvSurf(filenames, fun, output_surfstat)
 
 
 def BrainStatAvVol(filenames, fun, Nan):
-    return matlab_SurfStatAvVol(filenames, fun, Nan)
-
-
-def BrainStatColLim(clim):
-    return matlab_SurfStatColLim(clim)
-
-
-def BrainStatColormap(map):
-    return matlab_SurfStatColormap(map)
-
-
-def BrainStatCoord2Ind(coord, surf):
-    return matlab_SurfStatCoord2Ind(coord, surf)
-
-
-def BrainStatDataCursor(empt,event_obj):
-    return matlab_SurfStatDataCursor(empt,event_obj)
-
-
-def BrainStatDataCursorP(empt,event_obj):
-    return matlab_SurfStatDataCursorP(empt,event_obj)
-
-
-def BrainStatDataCursorQ(empt,event_obj):
-    return matlab_SurfStatDataCursorQ(empt,event_obj)
-
-
-def BrainStatDelete(varargin):
-    return matlab_SurfStatDelete(varargin)
+    return py_SurfStatAvVol(filenames, fun, Nan)
 
 
 def BrainStatEdge(surf):
-    return matlab_SurfStatEdge(surf)
+    return py_SurfStatEdge(surf)
 
 
 def BrainStatF(slm1, slm2):
-    return matlab_SurfStatF(slm1, slm2)
-
-
-def BrainStatInd2Coord(ind, surf):
-    return matlab_SurfStatInd2Coord(ind, surf)
-
-
-def BrainStatInflate(surf, w, spherefile):
-    return matlab_SurfStatInflate(surf, w, spherefile)
+    return py_SurfStatF(slm1, slm2)
 
 
 def BrainStatLinMod(Y, M, surf=None, niter=1, thetalim=0.01, drlim=0.1):
     return py_SurfStatLinMod(Y, M, surf, niter, thetalim, drlim)
 
 
-def BrainStatListDir(d, exclude):
-    return matlab_SurfStatListDir(d, exclude)
+def BrainStatNorm(Y, mask=None, subdiv='s'):
+    return py_SurfStatNorm(Y, mask, subdiv)
 
 
-def BrainStatMaskCut(surf):
-    return matlab_SurfStatMaskCut(surf)
+def BrainStatP(slm, mask=None, clusthresh=0.001):
+    return py_SurfStatP(slm, mask, clusthresh)
 
 
-def BrainStatNorm(Y, mask, subdiv):
-    return matlab_SurfStatNorm(Y, mask, subdiv)
+def BrainStatPeakClus(slm, mask, thresh, reselspvert=None, edg=None):
+    return py_SurfStatPeakClus(slm, mask, thresh, reselspvert, edg)
 
 
-def BrainStatP(slm, mask, clusthresh):
-    return matlab_SurfStatP(slm, mask, clusthresh)
+def BrainStatQ(slm, mask=None):
+    return py_SurfStatQ(slm, mask)
 
 
-def BrainStatPCA(Y, mask, X, k):
-    return matlab_SurfStatPCA(Y, mask, X, k)
-
-
-def BrainStatPeakClus(slm, mask, thresh, reselspvert, edg):
-    return matlab_SurfStatPeakClus(slm, mask, thresh, reselspvert, edg)
-
-
-def BrainStatPlot(x, y, M, g, varargin):
-    return matlab_SurfStatPlot(x, y, M, g, varargin)
-
-
-def BrainStatQ(slm, mask):
-    return matlab_SurfStatQ(slm, mask)
-
-
-def BrainStatROI(centre, radius, surf):
-    return matlab_SurfStatROI(centre, radius, surf)
-
-
-def BrainStatROILabel(lhlabel, rhlabel, nl, nr):
-    return matlab_SurfStatROILabel(lhlabel, rhlabel, nl, nr)
-
-
-def BrainStatReadData(filenames, dirname, maxmem):
-    return matlab_SurfStatReadData(filenames, dirname, maxmem)
-
-
-def BrainStatReadData1(filename):
-    return matlab_SurfStatReadData1(filename)
-
-
-def BrainStatReadSurf(filenames,ab,numfields,dirname,maxmem):
-    return matlab_SurfStatReadSurf(filenames,ab,numfields,dirname,maxmem)
-
-
-def BrainStatReadSurf1(filename, ab, numfields):
-    return matlab_SurfStatReadSurf1(filename, ab, numfields)
-
-
-def BrainStatReadVol(filenames,mask,step,dirname,maxmem):
-    return matlab_SurfStatReadVol(filenames,mask,step,dirname,maxmem)
-
-
-def BrainStatReadVol1(file, Z, T):
-    return matlab_SurfStatReadVol1(file, Z, T)
-
-
-def BrainStatResels(slm, mask):
-    return matlab_SurfStatResels(slm, mask)
+def BrainStatResels(slm, mask=None):
+    return py_SurfStatResels(slm, mask)
 
 
 def BrainStatSmooth(Y, surf, FWHM):
-    return matlab_SurfStatSmooth(Y, surf, FWHM)
+    return py_SurfStatSmooth(Y, surf, FWHM)
 
 
-def BrainStatStand(Y, mask, subtractordivide):
-    return matlab_SurfStatStand(Y, mask, subtractordivide)
-
-
-def BrainStatSurf2Vol(s, surf, template):
-    return matlab_SurfStatSurf2Vol(s, surf, template)
+def BrainStatStand(Y, mask=None, subtractordivide='s'):
+    return py_SurfStatStand(Y, mask, subtractordivide)
 
 
 def BrainStatT(slm, contrast):
-    return matlab_SurfStatT(slm, contrast)
-
-
-def BrainStatView(struct, surf, title, background):
-    return matlab_SurfStatView(struct, surf, title, background)
-
-
-def BrainStatView1(struct, surf, varargin):
-    return matlab_SurfStatView1(struct, surf, varargin)
-
-
-def BrainStatViewData(data, surf, title, background):
-    return matlab_SurfStatViewData(data, surf, title, background)
-
-
-def BrainStatViews(data, vol, z, layout):
-    return matlab_SurfStatViews(data, vol, z, layout)
-
-
-def BrainStatVol2Surf(vol, surf):
-    return matlab_SurfStatVol2Surf(vol, surf)
-
-
-def BrainStatWriteData(filename, data, ab):
-    return matlab_SurfStatWriteData(filename, data, ab)
-
-
-def BrainStatWriteSurf(filenames, surf, ab):
-    return matlab_SurfStatWriteSurf(filenames, surf, ab)
-
-
-def BrainStatWriteSurf1(filename, surf, ab):
-    return matlab_SurfStatWriteSurf1(filename, surf, ab)
-
-
-def BrainStatWriteVol(filenames, data, vol):
-    return matlab_SurfStatWriteVol(filenames, data, vol)
-
-
-def BrainStatWriteVol(d, Z, T):
-    return matlab_SurfStatWriteVol(d, Z, T)
+    return py_SurfStatT(slm, contrast)


### PR DESCRIPTION
Hi, 
`brainstat_surfstat.py` acts now as an interface. Functions there have elegant names starting with **BrainStat***, that call corresponding **py_SurfStat*** scripts.

(The reason for not renaming  **py_SurfStat*** functions is 1) to avoid losing our nice history and 2) to be able to debug possible python-matlab missmatches in future, ie see `tests`).

```
>>> import numpy as np                                                                                                                                                                                         
>>> from brainstat_surfstat import BrainStatLinMod
>>> from term import Term

>>> n = np.random.randint(2, 100)
>>> v = np.random.randint(2, 100)
>>> Y = np.random.rand(n, v)
>>> M = np.random.rand(n, 2)
>>> M[:,0] = 1 # Constant term. 
>>> M = Term(B)
>>> surf = {'tri': np.random.randint(1, v, size=(n, 3))}
>>> slm = BrainStatLinMod(Y, M, surf)
```

Ideally, we will have different modules in BrainStat, ie. gene decoding. Later, we should be able to call it from the top level directory like this:

```
>>> from brainstat import brainstat_surfstat
>>> from brainstat import xx_genedecoding_xx


```
Very last stage would be then building:

`$ pip install brainstat
`


