### PR TITLE
[ENH] Python Code coverage

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: Python CI
 
 on: [push]
 

--- a/.github/workflows/python_coverage.yml
+++ b/.github/workflows/python_coverage.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest ptest-cov
+          pip install pytest pytest-cov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           git config remote.origin.fetch refs/heads/*:refs/remotes/origin/*
           git fetch origin test-data

--- a/.github/workflows/python_coverage.yml
+++ b/.github/workflows/python_coverage.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-20.04
     
     steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@master
+        with:
+          python-version: 3.8
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -17,11 +22,6 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           git config remote.origin.fetch refs/heads/*:refs/remotes/origin/*
           git fetch origin test-data
-      - uses: actions/checkout@v1
-      - name: Set up Python
-        uses: actions/setup-python@master
-        with:
-          python-version: 3.8
       - name: Generate coverage report
         run: |
           pip install pytest

--- a/.github/workflows/python_coverage.yml
+++ b/.github/workflows/python_coverage.yml
@@ -1,0 +1,28 @@
+name: Python Code Coverage
+on:
+  push:
+    branches:
+      - 'master'
+      - 'code-coverage' 
+jobs:
+  codecov:
+    name: Codecov Workflow
+    runs-on: ubuntu-20.04
+    
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@master
+        with:
+          python-version: 3.8
+      - name: Generate coverage report
+        run: |
+          pip install pytest
+          pip install pytest-cov
+          pytest --cov=./ --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: unittests

--- a/.github/workflows/python_coverage.yml
+++ b/.github/workflows/python_coverage.yml
@@ -24,8 +24,6 @@ jobs:
           git fetch origin test-data
       - name: Generate coverage report
         run: |
-          pip install pytest
-          pip install pytest-cov
           pytest --cov=./ --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/python_coverage.yml
+++ b/.github/workflows/python_coverage.yml
@@ -10,6 +10,13 @@ jobs:
     runs-on: ubuntu-20.04
     
     steps:
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest ptest-cov
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          git config remote.origin.fetch refs/heads/*:refs/remotes/origin/*
+          git fetch origin test-data
       - uses: actions/checkout@v1
       - name: Set up Python
         uses: actions/setup-python@master

--- a/.github/workflows/python_coverage.yml
+++ b/.github/workflows/python_coverage.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 'master'
-      - 'code-coverage' 
+      - 'code_coverage' 
 jobs:
   codecov:
     name: Codecov Workflow

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ BrainStat : A toolbox for statistical analysis of neuroimaging data
 
 
 [![Actions Status](https://github.com/MICA-LAB/brainstat/workflows/Python%20package/badge.svg)](https://github.com/MICA-LAB/brainstat/actions)
+[![codecov](https://codecov.io/gh/MICA-LAB/BrainStat/branch/master/graph/badge.svg?token=5O9PVCT9GA)](https://codecov.io/gh/MICA-LAB/BrainStat)
 
 BrainStat implements element-wise univariate and multivariate linear models, similar to one its predecessor [SurfStat](https://www.math.mcgill.ca/keith/surfstat/).
 


### PR DESCRIPTION
This PR adds code coverage based on Pytest and Codecov. Coverage is set to run only on the master branch and this branch. 

Coverage report is available at: https://app.codecov.io/gh/MICA-LAB/BrainStat/branch/code_coverage. 

I've also included a code coverage badge in the README.md. Note that this badge is synced to the master branch which hasn't run a code coverage yet, so this badge will only display a coverage number after merging. 