### PR TITLE
[ENH] Allow Term inputs, set slm['t'] to 1D. 

### DIFF
--- a/brainstat/stats/models.py
+++ b/brainstat/stats/models.py
@@ -160,8 +160,8 @@ def linear_model(Y, M, surf=None, niter=1, thetalim=0.01, drlim=0.1):
 
     Parameters
     ----------
-    Y : numpy.array, Term
-        Input data of shape (samples, vertices) or (samples, vertices, features).
+    Y : numpy array
+        Input data of shape (samples, vertices, features).
     M : Term, Random
         Design matrix.
     surf : dict, BSPolyData, optional
@@ -198,9 +198,6 @@ def linear_model(Y, M, surf=None, niter=1, thetalim=0.01, drlim=0.1):
     - slm['lat'] : (numpy.array) Neighbors in the input lattice.
 
     """
-
-    if isinstance(Y, Term):
-        Y = Y.m.to_numpy()
 
     n, v = Y.shape[:2]  # number of samples x number of points
     k = 1 if Y.ndim == 2 else Y.shape[2]  # number of features
@@ -421,7 +418,7 @@ def t_test(slm, contrast):
     ----------
     slm : dict
         Standard linear model, see Notes for details.
-    contrast : numpy.array, Term
+    contrast : numpy.array
         Vector containing the contrast in observations.
 
     Returns
@@ -464,9 +461,6 @@ def t_test(slm, contrast):
     design matrix in slm.X. Note that the redundant columns of the design matrix
     have weights given by the rows of null(slm.X,'r')'
     """
-
-    if isinstance(contrast, Term):
-        contrast = contrast.m.to_numpy()
 
     def null(A, eps=1e-15):
         u, s, vh = scipy.linalg.svd(A)

--- a/brainstat/stats/models.py
+++ b/brainstat/stats/models.py
@@ -160,8 +160,8 @@ def linear_model(Y, M, surf=None, niter=1, thetalim=0.01, drlim=0.1):
 
     Parameters
     ----------
-    Y : numpy array
-        Input data of shape (samples, vertices, features).
+    Y : numpy.array, Term
+        Input data of shape (samples, vertices) or (samples, vertices, features).
     M : Term, Random
         Design matrix.
     surf : dict, BSPolyData, optional
@@ -198,6 +198,9 @@ def linear_model(Y, M, surf=None, niter=1, thetalim=0.01, drlim=0.1):
     - slm['lat'] : (numpy.array) Neighbors in the input lattice.
 
     """
+
+    if isinstance(Y, Term):
+        Y = Y.m.to_numpy()
 
     n, v = Y.shape[:2]  # number of samples x number of points
     k = 1 if Y.ndim == 2 else Y.shape[2]  # number of features
@@ -418,7 +421,7 @@ def t_test(slm, contrast):
     ----------
     slm : dict
         Standard linear model, see Notes for details.
-    contrast : numpy.array
+    contrast : numpy.array, Term
         Vector containing the contrast in observations.
 
     Returns
@@ -461,6 +464,9 @@ def t_test(slm, contrast):
     design matrix in slm.X. Note that the redundant columns of the design matrix
     have weights given by the rows of null(slm.X,'r')'
     """
+
+    if isinstance(contrast, Term):
+        contrast = contrast.m.to_numpy()
 
     def null(A, eps=1e-15):
         u, s, vh = scipy.linalg.svd(A)

--- a/brainstat/stats/models.py
+++ b/brainstat/stats/models.py
@@ -642,4 +642,5 @@ def t_test(slm, contrast):
         slm['t'] = np.multiply(
             np.sqrt(slm['t'] + (slm['t'] <= 0)), (slm['t'] > 0))
 
+    slm['t'] = np.squeeze(slm['t'])
     return slm

--- a/brainstat/stats/multiple_comparisons.py
+++ b/brainstat/stats/multiple_comparisons.py
@@ -132,30 +132,30 @@ def random_field_theory(slm, mask=None, clusthresh=0.001):
     Returns
     -------
     pval : a dictionary with keys 'P', 'C', 'mask'.
-        pval['P'] : 2D numpy array of shape (1,v).
+        pval['P'] : numpy array of shape (v).
             Corrected P-values for vertices.
-        pval['C'] : 2D numpy array of shape (1,v).
+        pval['C'] : numpy array of shape (v).
             Corrected P-values for clusters.
         pval['mask'] : copy of input mask.
     peak : a dictionary with keys 't', 'vertid', 'clusid', 'P'.
-        peak['t'] : 2D numpy array of shape (np,1).
+        peak['t'] : numpy array of shape (np).
             Peaks (local maxima).
-        peak['vertid'] : 2D numpy array of shape (np,1).
+        peak['vertid'] : numpy array of shape (np).
             Vertex.
-        peak['clusid'] : 2D numpy array of shape (np,1).
+        peak['clusid'] : numpy array of shape (np).
             Cluster id numbers.
-        peak['P'] : 2D numpy array of shape (np,1).
+        peak['P'] : numpy array of shape (np).
             Corrected P-values for the peak.
     clus : a dictionary with keys 'clusid', 'nverts', 'resels', 'P.'
-        clus['clusid'] : 2D numpy array of shape (nc,1).
+        clus['clusid'] : numpy array of shape (nc).
             Cluster id numbers
-        clus['nverts'] : 2D numpy array of shape (nc,1).
+        clus['nverts'] : numpy array of shape (nc).
             Number of vertices in cluster.
-        clus['resels'] : 2D numpy array of shape (nc,1).
+        clus['resels'] : numpy array of shape (nc).
             resels in the cluster.
-        clus['P'] : 2D numpy array of shape (nc,1).
+        clus['P'] : numpy array of shape (nc).
             Corrected P-values for the cluster.
-    clusid : 2D numpy array of shape (1,v).
+    clusid : numpy array of shape (v).
         Cluster id's for each vertex.
 
     Reference: Worsley, K.J., Andermann, M., Koulis, T., MacDonald, D.
@@ -252,6 +252,13 @@ def random_field_theory(slm, mask=None, clusthresh=0.001):
     tlim = tlim[1]
     pval['P'] = pval['P'] * (slm['t'][0, :] > tlim) + (slm['t'][0, :] <= tlim)
     pval['mask'] = mask
+
+    # Squeeze the outputs - this should probably be done in-code rather than this 
+    # hackish way at the end.
+    pval = {k: np.squeeze(v) for k, v in pval.items()}
+    peak = {k: np.squeeze(v) for k, v in peak.items()}
+    clus = {k: np.squeeze(v) for k, v in clus.items()}
+    clusid = {k: np.squeeze(v) for k, v in clusid.items()}
 
     return pval, peak, clus, clusid
 

--- a/brainstat/stats/multiple_comparisons.py
+++ b/brainstat/stats/multiple_comparisons.py
@@ -49,7 +49,8 @@ def fdr(slm, mask=None):
 
     Note that slm['tri'] and slm['lat'] are mutually exclusive.
     """
-    l, v = np.shape(slm['t'])
+    slm['t'] = np.atleast_2d(slm['t'])
+    _, v = np.shape(slm['t'])
 
     if mask is None:
         mask = np.ones((v), dtype='bool')
@@ -161,7 +162,8 @@ def random_field_theory(slm, mask=None, clusthresh=0.001):
     & Evans, A.C. (1999). Detecting changes in nonisotropic images.
     Human Brain Mapping, 8:98-101.
     """
-    l, v = np.shape(slm['t'])
+    slm['t'] = np.atleast_2d(slm['t'])
+    _, v = np.shape(slm['t'])
 
     if mask is None:
         mask = np.ones((v), dtype=bool)
@@ -813,6 +815,7 @@ def peak_clus(slm, mask, thresh, reselspvert=None, edg=None):
     if edg is None:
         edg = mesh_edges(slm)
 
+    slm['t'] = np.atleast_2d(slm['t'])
     l, v = np.shape(slm['t'])
     slm_t = copy.deepcopy(slm['t'])
     slm_t[0, ~mask.astype(bool)] = slm_t[0, :].min()

--- a/brainstat/stats/terms.py
+++ b/brainstat/stats/terms.py
@@ -155,8 +155,8 @@ class Term:
     x : array-like or DataFrame, optional
         If None, the term is empty. Default is None.
     names : str or list of str, optional
-        Names for each column in `x`. If None, it defauts to {'x0', 'x1', ...}.
-        Default is None.
+        Names for each column in `x`. If None, it defaults to 'intercept' if x
+        is a scalar or {'x0', 'x1', ...} otherwise. Default is None.
 
     Attributes
     ----------
@@ -194,6 +194,9 @@ class Term:
         if isinstance(x, Term):
             self.m = x.m
             return
+
+        if np.isscalar(x) and names is None:
+            names = ['intercept']
 
         if isinstance(names, str):
             names = [names]

--- a/brainstat/stats/terms.py
+++ b/brainstat/stats/terms.py
@@ -155,8 +155,8 @@ class Term:
     x : array-like or DataFrame, optional
         If None, the term is empty. Default is None.
     names : str or list of str, optional
-        Names for each column in `x`. If None, it defaults to 'intercept' if x
-        is a scalar or {'x0', 'x1', ...} otherwise. Default is None.
+        Names for each column in `x`. If None, it defauts to {'x0', 'x1', ...}.
+        Default is None.
 
     Attributes
     ----------
@@ -194,9 +194,6 @@ class Term:
         if isinstance(x, Term):
             self.m = x.m
             return
-
-        if np.isscalar(x) and names is None:
-            names = ['intercept']
 
         if isinstance(names, str):
             names = [names]


### PR DESCRIPTION
Implementing changes mentioned in #80 to make BrainStat more user-friendly. Currently the slm['t'] change is rather ugly, so this should be resolved in the long run. 