### PR TITLE
[ENH] Allow term input to t_test and linear model

### DIFF
--- a/brainstat/stats/models.py
+++ b/brainstat/stats/models.py
@@ -201,7 +201,7 @@ def linear_model(Y, M, surf=None, niter=1, thetalim=0.01, drlim=0.1):
 
     if isinstance(Y, Term):
         Y = Y.m.to_numpy()
-    
+
     n, v = Y.shape[:2]  # number of samples x number of points
     k = 1 if Y.ndim == 2 else Y.shape[2]  # number of features
 

--- a/brainstat/stats/models.py
+++ b/brainstat/stats/models.py
@@ -199,6 +199,9 @@ def linear_model(Y, M, surf=None, niter=1, thetalim=0.01, drlim=0.1):
 
     """
 
+    if isinstance(Y, Term):
+        Y = Y.m.to_numpy()
+    
     n, v = Y.shape[:2]  # number of samples x number of points
     k = 1 if Y.ndim == 2 else Y.shape[2]  # number of features
 
@@ -461,6 +464,9 @@ def t_test(slm, contrast):
     design matrix in slm.X. Note that the redundant columns of the design matrix
     have weights given by the rows of null(slm.X,'r')'
     """
+
+    if isinstance(contrast, Term):
+        contrast = contrast.m.to_numpy()
 
     def null(A, eps=1e-15):
         u, s, vh = scipy.linalg.svd(A)

--- a/brainstat/stats/terms.py
+++ b/brainstat/stats/terms.py
@@ -197,7 +197,7 @@ class Term:
 
         if np.isscalar(x) and names is None:
             names = ['intercept']
- 
+
         if isinstance(names, str):
             names = [names]
 

--- a/brainstat/stats/terms.py
+++ b/brainstat/stats/terms.py
@@ -195,6 +195,9 @@ class Term:
             self.m = x.m
             return
 
+        if np.isscalar(x) and names is None:
+            names = ['intercept']
+            
         if isinstance(names, str):
             names = [names]
 

--- a/brainstat/stats/terms.py
+++ b/brainstat/stats/terms.py
@@ -197,7 +197,7 @@ class Term:
 
         if np.isscalar(x) and names is None:
             names = ['intercept']
-            
+ 
         if isinstance(names, str):
             names = [names]
 


### PR DESCRIPTION
This PR allows for Term input to t_test and linear_model, and if a Term is created with a scalar and no name it is automatically labelled as 'intercept'. 